### PR TITLE
[FIX] 회원 정보 변경에 따른 게시글 조회 API 종류 수정

### DIFF
--- a/src/api/post.ts
+++ b/src/api/post.ts
@@ -3,23 +3,23 @@ const router = express.Router();
 import { postController } from '../controller';
 
 /**
- *  @route GET /post/detail/:userId/:postId
+ *  @route GET /post/detail/:userEmail/:postId
  *  @desc 게시글 상세정보 조회
  *  @access Public
  */
-router.get('/detail/:userId/:postId', postController.readPost);
+router.get('/detail/:userEmail/:postId', postController.readPost);
 
 /**
- *  @route GET /post/like/:userId/:postId
+ *  @route GET /post/like/:userEmail/:postId
  *  @desc 게시글 더보기 조회(인기순)
  *  @access Public
  */
-router.get('/preview/like/:userId/:identifier', postController.readLikePreview);
+router.get('/preview/like/:userEmail/:identifier', postController.readLikePreview);
 
 /**
- *  @route GET /post/new/:userId/:postId
+ *  @route GET /post/new/:userEmail/:postId
  *  @desc 게시글 더보기 조회(최신순)
  *  @access Public
  */
-router.get('/preview/new/:userId/:identifier', postController.readNewPreview);
+router.get('/preview/new/:userEmail/:identifier', postController.readNewPreview);
 export default router;

--- a/src/controller/postController.ts
+++ b/src/controller/postController.ts
@@ -2,51 +2,50 @@ import express, { Request, Response } from 'express';
 
 import { getDetail } from '../service/detailService';
 import { getLikeTrend, getLikeTheme, getLikeLocal, getNewTrend } from '../service/previewService';
-// userId 검사는.... 따로 빼야되는데, 사실?! 실제로는 이상한 아이디가 들어올 수 없지 않나.
+// userEmail 검사는.... 따로 빼야되는데, 사실?! 실제로는 이상한 아이디가 들어올 수 없지 않나.
 
 const readPost = async function readPost(req: Request, res: Response) {
-  const { userId, postId } = req.params;
-  console.log(userId, postId);
+  const { userEmail, postId } = req.params;
 
-  const result = await getDetail(userId, postId);
+  const result = await getDetail(userEmail, postId);
 
   return res.status(result.status).json(result.data);
 };
 
 const readLikePreview = async function readPost(req: Request, res: Response) {
-  const { userId, identifier } = req.params;
+  const { userEmail, identifier } = req.params;
   const { value } = req.query;
 
   let result: any;
 
   if (identifier == '0') {
-    result = await getLikeTrend(userId);
+    result = await getLikeTrend(userEmail);
   } else if (identifier == '1') {
-    result = await getLikeTheme(userId, value as string);
+    result = await getLikeTheme(userEmail, value as string);
   } else if (identifier == '2') {
-    result = await getLikeLocal(userId, value as string);
+    result = await getLikeLocal(userEmail, value as string);
   } else if (identifier == '3') {
     // cumstom_theme 값 ( 관리자 권한 )
-    result = await getLikeTheme(userId, 'river');
+    result = await getLikeTheme(userEmail, 'river');
   }
   return res.status(result.status).json(result.data);
 };
 
 const readNewPreview = async function readPost(req: Request, res: Response) {
-  const { userId, identifier } = req.params;
+  const { userEmail, identifier } = req.params;
   const { value } = req.query;
 
   let result: any;
 
   if (identifier == '0') {
-    result = await getNewTrend(userId);
+    result = await getNewTrend(userEmail);
   } else if (identifier == '1') {
-    result = await getLikeTheme(userId, value as string);
+    result = await getLikeTheme(userEmail, value as string);
   } else if (identifier == '2') {
-    result = await getLikeLocal(userId, value as string);
+    result = await getLikeLocal(userEmail, value as string);
   } else if (identifier == '3') {
     // cumstom_theme 값 ( 관리자 권한 )
-    result = await getLikeTheme(userId, 'river');
+    result = await getLikeTheme(userEmail, 'river');
   }
   return res.status(result.status).json(result.data);
 };

--- a/src/controller/registerController.ts
+++ b/src/controller/registerController.ts
@@ -4,7 +4,7 @@ import config from '../config/config';
 import { registerDTO } from '../interface/req/registerDTO';
 import registerService from '../service/registerService';
 const register = async function (req: Request, res: Response) {
-  const { email, userId, password, profileImage, nickname, pushAgree, emailAgree } = req.body;
+  const { email, userEmail, password, profileImage, nickname, pushAgree, emailAgree } = req.body;
 
   const user: registerDTO = {
     email: email,

--- a/src/models/SearchHistory.ts
+++ b/src/models/SearchHistory.ts
@@ -2,7 +2,7 @@ import { DataTypes, Model, Sequelize } from 'sequelize';
 import sequelize from '../loaders/database';
 
 export default class SearchHistory extends Model {
-  public UserId!: string;
+  public UserEmail!: string;
   public title!: string;
   public address!: string;
   public latitude!: string;
@@ -15,7 +15,7 @@ export default class SearchHistory extends Model {
 
 SearchHistory.init(
   {
-    UserId: {
+    UserEmail: {
       type: DataTypes.STRING(20),
       primaryKey: true,
       allowNull: false,

--- a/src/service/detailService.ts
+++ b/src/service/detailService.ts
@@ -5,21 +5,21 @@ import { detailDTO, courseDTO } from '../interface/res/detailDTO';
 
 import mapping from './mapping.json';
 
-export async function getDetail(userId: string, postId: string) {
+export async function getDetail(userEmail: string, postId: string) {
   try {
     const query = `SELECT P.*, user.nickname, user.profileImage, 
                     count(isSave.PreviewId) as isStored, count(countLike.PreviewId) as favoriteCount, count(isLike.PreviewId) as isFavorite
                     FROM detail as P
                     INNER JOIN user
-                    LEFT OUTER JOIN savedPost as isSave ON(isSave.PreviewId = P.PostId and isSave.UserId =:userId)
+                    LEFT OUTER JOIN savedPost as isSave ON(isSave.PreviewId = P.PostId and isSave.UserEmail =:userEmail)
                     LEFT OUTER JOIN likedPost as countLike ON(countLike.PreviewId = P.PostId)
-                    LEFT OUTER JOIN likedPost as isLike ON(isLike.PreviewId = P.PostId and isLike.UserId =:userId)
-                    WHERE user.Id = P.UserId
+                    LEFT OUTER JOIN likedPost as isLike ON(isLike.PreviewId = P.PostId and isLike.UserEmail =:userEmail)
+                    WHERE user.email = P.UserEmail
                     GROUP BY P.PostId`;
 
     const result = await db.sequelize.query(query, {
       type: QueryTypes.SELECT,
-      replacements: { userId: userId },
+      replacements: { userEmail: userEmail },
       raw: true,
       nest: true,
     });
@@ -35,7 +35,7 @@ export async function getDetail(userId: string, postId: string) {
       warnings: parseWarning(data),
 
       author: data['nickname'],
-      isAuthor: data['UserId'] == userId ? true : false,
+      isAuthor: data['userEmail'] == userEmail ? true : false,
       profileImage: data['profileImage'],
 
       likesCount: data['favoriteCount'],

--- a/src/service/previewService.ts
+++ b/src/service/previewService.ts
@@ -4,18 +4,18 @@ import { makePreview } from './makePreview';
 
 import mapping from './mapping.json';
 
-export async function getLikeTrend(userId: string) {
+export async function getLikeTrend(userEmail: string) {
   try {
     const query = `SELECT P.Id, P.title, P.image, P.region, P.theme, P.warning, 
                     DATE_FORMAT(P.createdAt, '%Y-%m-%d') as date, count(isLike.PreviewId) as isFavorite, count(countLike.PreviewId) as favoriteCount
                     FROM preview as P
                     LEFT OUTER JOIN likedPost as countLike ON(countLike.PreviewId = P.Id)
-                    LEFT OUTER JOIN likedPost as isLike ON(isLike.PreviewId = P.Id and isLike.UserId =:userId)
+                    LEFT OUTER JOIN likedPost as isLike ON(isLike.PreviewId = P.Id and isLike.UserEmail =:userEmail)
                     GROUP BY P.Id ORDER BY favoriteCount`;
 
     const result = await db.sequelize.query(query, {
       type: QueryTypes.SELECT,
-      replacements: { userId: userId },
+      replacements: { userEmail: userEmail },
       raw: true,
       nest: true,
     });
@@ -41,20 +41,20 @@ export async function getLikeTrend(userId: string) {
   }
 }
 
-export async function getLikeTheme(userId: string, theme: string) {
+export async function getLikeTheme(userEmail: string, theme: string) {
   try {
     const query = `SELECT P.Id, P.title, P.image, P.region, P.theme, P.warning, 
                       DATE_FORMAT(P.createdAt, '%Y-%m-%d') as date, count(isLike.PreviewId) as isFavorite, count(countLike.PreviewId) as favoriteCount
                       FROM preview as P
                       INNER JOIN detail 
                       LEFT OUTER JOIN likedPost as countLike ON(countLike.PreviewId = P.Id)
-                      LEFT OUTER JOIN likedPost as isLike ON(isLike.PreviewId = P.Id and isLike.UserId =:userId)
+                      LEFT OUTER JOIN likedPost as isLike ON(isLike.PreviewId = P.Id and isLike.UserEmail =:userEmail)
                       WHERE detail.PostId=P.Id and detail.${theme}= 1
                       GROUP BY P.Id ORDER BY favoriteCount`;
 
     const result = await db.sequelize.query(query, {
       type: QueryTypes.SELECT,
-      replacements: { userId: userId },
+      replacements: { userEmail: userEmail },
       raw: true,
       nest: true,
     });
@@ -79,20 +79,20 @@ export async function getLikeTheme(userId: string, theme: string) {
   }
 }
 
-export async function getLikeLocal(userId: string, local: string) {
+export async function getLikeLocal(userEmail: string, local: string) {
   try {
     const query = `SELECT P.Id, P.title, P.image, P.region, P.theme, P.warning, 
                         DATE_FORMAT(P.createdAt, '%Y-%m-%d') as date, count(isLike.PreviewId) as isFavorite, count(countLike.PreviewId) as favoriteCount
                         FROM preview as P
                         INNER JOIN detail
                         LEFT OUTER JOIN likedPost as countLike ON(countLike.PreviewId = P.Id) 
-                        LEFT OUTER JOIN likedPost as isLike ON(isLike.PreviewId = P.Id and isLike.UserId =:userId)
+                        LEFT OUTER JOIN likedPost as isLike ON(isLike.PreviewId = P.Id and isLike.UserEmail =:userEmail)
                         WHERE P.region =:region
                         GROUP BY P.Id ORDER BY favoriteCount`;
 
     const result = await db.sequelize.query(query, {
       type: QueryTypes.SELECT,
-      replacements: { userId: userId, region: mapping.region[local] },
+      replacements: { userEmail: userEmail, region: mapping.region[local] },
       raw: true,
       nest: true,
     });
@@ -117,17 +117,17 @@ export async function getLikeLocal(userId: string, local: string) {
   }
 }
 
-export async function getNewTrend(userId: string) {
+export async function getNewTrend(userEmail: string) {
   try {
     const query = `SELECT P.Id, P.title, P.image, P.region, P.theme, P.warning, 
                       DATE_FORMAT(P.createdAt, '%Y-%m-%d') as date, count(isLike.PreviewId) as isFavorite
                       FROM preview as P
-                      LEFT OUTER JOIN likedPost as isLike ON(isLike.PreviewId = P.Id and isLike.UserId =:userId)
+                      LEFT OUTER JOIN likedPost as isLike ON(isLike.PreviewId = P.Id and isLike.UserEmail =:userEmail)
                       GROUP BY P.Id ORDER BY date`;
 
     const result = await db.sequelize.query(query, {
       type: QueryTypes.SELECT,
-      replacements: { userId: userId },
+      replacements: { userEmail: userEmail },
       raw: true,
       nest: true,
     });
@@ -152,19 +152,19 @@ export async function getNewTrend(userId: string) {
   }
 }
 
-export async function getNewTheme(userId: string, theme: string) {
+export async function getNewTheme(userEmail: string, theme: string) {
   try {
     const query = `SELECT P.Id, P.title, P.image, P.region, P.theme, P.warning, 
                         DATE_FORMAT(P.createdAt, '%Y-%m-%d') as date, count(isLike.PreviewId) as isFavorite
                         FROM preview as P
                         INNER JOIN detail 
-                        LEFT OUTER JOIN likedPost as isLike ON(isLike.PreviewId = P.Id and isLike.UserId =:userId)
+                        LEFT OUTER JOIN likedPost as isLike ON(isLike.PreviewId = P.Id and isLike.UserEmail =:userEmail)
                         WHERE detail.PostId=P.Id and detail.${theme}= 1
                         GROUP BY P.Id ORDER BY date`;
 
     const result = await db.sequelize.query(query, {
       type: QueryTypes.SELECT,
-      replacements: { userId: userId },
+      replacements: { userEmail: userEmail },
       raw: true,
       nest: true,
     });
@@ -190,19 +190,19 @@ export async function getNewTheme(userId: string, theme: string) {
   }
 }
 
-export async function getNewLocal(userId: string, local: string) {
+export async function getNewLocal(userEmail: string, local: string) {
   try {
     const query = `SELECT P.Id, P.title, P.image, P.region, P.theme, P.warning, 
                           DATE_FORMAT(P.createdAt, '%Y-%m-%d') as date, count(isLike.PreviewId) as isFavorite
                           FROM preview as P
                           INNER JOIN detail
-                          LEFT OUTER JOIN likedPost as isLike ON(isLike.PreviewId = P.Id and isLike.UserId =:userId)
+                          LEFT OUTER JOIN likedPost as isLike ON(isLike.PreviewId = P.Id and isLike.UserEmail =:userEmail)
                           WHERE P.region =:region
                           GROUP BY P.Id ORDER BY date`;
 
     const result = await db.sequelize.query(query, {
       type: QueryTypes.SELECT,
-      replacements: { userId: userId, region: mapping.region[local] },
+      replacements: { userEmail: userEmail, region: mapping.region[local] },
       raw: true,
       nest: true,
     });


### PR DESCRIPTION
* 상세조회 API  / 프리뷰 API 게시글 속 유저 아이디 활용 부분들을 유저 이메일로 변경합니다.

Closes #21 