### PR TITLE
[FIX] 유저 팔로잉/팔로우 목록 조회 route 수정/설명 추가

### DIFF
--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -99,6 +99,11 @@ router.get('/myPage/new/:userEmail/save/:postId', myPageController.myPageNewMore
  */
 router.post('/follow', utilController.follow);
 
-router.get('/followers', utilController.getFollowers);
+/**
+ *  @route GET /user/follow
+ *  @desc 유저의 팔로우/팔로잉 목록 조회
+ *  @access Public
+ */
+router.get('/follow', utilController.getFollowers);
 
 export default router;


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 
  closed: #Issue_number를 적어주세요 -->
  Closed: #67 

## 📌 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
- 현재 팔로우/팔로잉 조회 API는 마이페이지-현 로그인유저가 같은경우로 되어있다.
- 다른 유저의 마이페이지일 경우에는 다르게 동작해야하는데, 이는 token을 이용해 이후 리팩토링에 적용하도록 합니다.
